### PR TITLE
Use Whenever to set cron job to get collision data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'soda-ruby', require: 'soda'
 gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
+gem 'whenever', require: false
 
 group :development do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
       tzinfo (~> 1.1)
     arel (5.0.1.20140414130214)
     builder (3.2.2)
+    chronic (0.10.2)
     coderay (1.1.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -121,6 +122,8 @@ GEM
     uglifier (2.5.3)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    whenever (0.9.4)
+      chronic (>= 0.6.3)
 
 PLATFORMS
   ruby
@@ -141,3 +144,4 @@ DEPENDENCIES
   soda-ruby
   turbolinks
   uglifier (>= 1.3.0)
+  whenever

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,6 +1,5 @@
 class HomesController < ApplicationController
   def show
-    Home.new
     marker_builder = GeojsonBuilder.new(Incident.all)
     @marker_data_set = marker_builder.to_json
   end

--- a/app/models/home.rb
+++ b/app/models/home.rb
@@ -1,6 +1,0 @@
-class Home
-  def initialize
-    collision_data = NypdCollisionData.new
-    collision_data.get_incidents
-  end
-end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,3 @@
+every 1.day, at: "7:00 am" do
+  runner "NypdCollisionData.new.get_incidents"
+end


### PR DESCRIPTION
- Install cron job gem Whenever
- Set cron job to get collision data at 2am every morning
- Remove unnecessary and unfortunate Home model
- Whenever should work on Digital Ocean
- Will have to use Heroku Scheduler instead if using Heroku
